### PR TITLE
Setting the default sales person

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -46,7 +46,8 @@ class NineteenEightyWoo {
 		let customerNumberPrefix   = formData.get( 'customer_number_prefix' ).trim();
 		let defaultKennitala       = formData.get( 'default_kennitala' ).trim();
 		let enableKennitala        = Boolean( formData.get( 'enable_kennitala' ) );
-		let enableKennitalaInBlock = Boolean( formData.get( 'enable_kennitala_in_block' ) )
+		let enableKennitalaInBlock = Boolean( formData.get( 'enable_kennitala_in_block' ) );
+		let defaultSalesPerson     = formData.get( 'default_sales_person' );
 		let paymentIds             = formData.getAll( 'payment_id' );
 		let paymentMethods         = [];
 		let paymentsLength         = paymentIds.length;
@@ -76,6 +77,7 @@ class NineteenEightyWoo {
 			default_kennitala: defaultKennitala,
 			enable_kennitala: enableKennitala,
 			enable_kennitala_in_block: enableKennitalaInBlock,
+			default_sales_person: defaultSalesPerson,
 			payment_methods: paymentMethods
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,10 @@ In the most simple terms this WordPress plugin syncs information between a WooCo
 - [x] Map Payment Gateways in WooCommerce with Payment Methods in DK
 
 #### Salesperson
-- [ ] Assign a *salesperson* in DK for sales in WooCommerce
+- [x] Assign a *salesperson* in DK for sales in WooCommerce
+
+#### Prices
+- [ ] Assign a *price group* (1, 2 , 3) for products
 
 ### Future Features (after the first release)
 - [ ] Sync WooCommerce orders with the *DK Sales Order* module

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace NineteenEightyFour\NineteenEightyWoo;
 
+use NineteenEightyFour\NineteenEightyWoo\Export\Employee;
+use NineteenEightyFour\NineteenEightyWoo\Export\SalesPerson;
 use NineteenEightyFour\NineteenEightyWoo\Export\ServiceSKU;
 use NineteenEightyFour\NineteenEightyWoo\Import\SalesPayments;
 use NineteenEightyFour\NineteenEightyWoo\Hooks\KennitalaField;
@@ -24,6 +26,8 @@ class Config {
 	const DEFAULT_SHIPPING_SKU = 'SHIPPING';
 	const DEFAULT_COUPON_SKU   = 'COUPON';
 	const DEFAULT_COST_SKU     = 'COST';
+
+	const DEFAULT_SALES_PERSON = 'WEBSALES';
 
 	/**
 	 * Get the DK API key
@@ -315,6 +319,53 @@ class Config {
 		return update_option(
 			'1984_woo_dk_kennitala_block_field_enabled',
 			$enabled
+		);
+	}
+
+	/**
+	 * Get the default sales person number
+	 */
+	public static function get_default_sales_person_number(): string {
+		return (string) get_option(
+			'1984_woo_dk_default_sales_person_number',
+			self::DEFAULT_SALES_PERSON
+		);
+	}
+
+	/**
+	 * Set the default sales person number
+	 *
+	 * @param string $sales_person_number The sales person number.
+	 */
+	public static function set_default_sales_person_number(
+		string $sales_person_number
+	): bool {
+		if ( self::get_default_sales_person_number() !== $sales_person_number ) {
+			return false;
+		}
+
+		if ( false === SalesPerson::is_in_dk( $sales_person_number ) ) {
+			$random_string = base_convert(
+				(string) random_int( 65_536, 131_072 ),
+				10,
+				36
+			);
+
+			$employee_number = 'WEBSALES' . $random_string;
+			if ( true !== Employee::create_in_dk( $employee_number ) ) {
+				return false;
+			}
+
+			if ( true !== SalesPerson::create_in_dk(
+				$sales_person_number,
+				$employee_number
+			) ) {
+				return false;
+			}
+		}
+		return update_option(
+			'1984_woo_dk_default_sales_person_number',
+			$sales_person_number
 		);
 	}
 }

--- a/src/Export/Employee.php
+++ b/src/Export/Employee.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace NineteenEightyFour\NineteenEightyWoo\Export;
+
+use NineteenEightyFour\NineteenEightyWoo\Service\DKApiRequest;
+use WP_Error;
+use stdClass;
+
+/**
+ * The Employee Export class
+ */
+class Employee {
+	const API_PATH                = '/General/Employee/';
+	const DEFAULT_EMPLOYEE_NUMBER = 'WEBSALES';
+
+	/**
+	 * Create an employee record in DK
+	 *
+	 * @param string $employee_number The employee number.
+	 * @param string $employee_name The employee name.
+	 */
+	public static function create_in_dk(
+		string $employee_number = self::DEFAULT_EMPLOYEE_NUMBER,
+		string $employee_name = 'Online Store'
+	): bool|WP_Error {
+		$api_request  = new DKApiRequest();
+		$request_body = self::to_dk_employee_body(
+			$employee_number,
+			$employee_name
+		);
+
+		$result = $api_request->request_result(
+			self::API_PATH,
+			wp_json_encode( $request_body )
+		);
+
+		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		if ( 200 !== $result->response_code ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get an employee record from DK
+	 *
+	 * @param string $employee_number The employee number.
+	 */
+	public static function get_from_dk(
+		string $employee_number = self::DEFAULT_EMPLOYEE_NUMBER
+	): stdClass|bool|WP_Error {
+		$api_request = new DKApiRequest();
+
+		$result = $api_request->get_result(
+			self::API_PATH . $employee_number
+		);
+
+		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		if ( 200 !== $result->response_code ) {
+			return false;
+		}
+
+		return $result->data;
+	}
+
+	/**
+	 * Check if an employee is in DK
+	 *
+	 * @param string $employee_number The employee number.
+	 */
+	public static function is_in_dk(
+		string $employee_number = self::DEFAULT_EMPLOYEE_NUMBER
+	): bool|WP_Error {
+		$dk_record = self::get_from_dk( $employee_number );
+
+		if ( $dk_record instanceof stdClass ) {
+			return true;
+		}
+
+		return $dk_record;
+	}
+
+	/**
+	 * Prepare an employee POST request body
+	 *
+	 * @param string $employee_number The employee number.
+	 * @param string $employee_name The employee name.
+	 */
+	public static function to_dk_employee_body(
+		string $employee_number = 'WEBSALES',
+		string $employee_name = 'Online Store'
+	): array {
+		return array(
+			'Number' => $employee_number,
+			'Name'   => $employee_name,
+		);
+	}
+}

--- a/src/Export/SalesPerson.php
+++ b/src/Export/SalesPerson.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace NineteenEightyFour\NineteenEightyWoo\Export;
+
+use NineteenEightyFour\NineteenEightyWoo\Service\DKApiRequest;
+use WP_Error;
+use stdClass;
+
+/**
+ * The Sales Person Export class
+ */
+class SalesPerson {
+	const API_PATH                    = '/Sales/Person/';
+	const DEFAULT_SALES_PERSON_NUMBER = 'WEBSALES';
+
+	/**
+	 * Create a sales person record in DK
+	 *
+	 * @param string $sales_person_number The sales person number.
+	 * @param string $employee_number The employee number.
+	 */
+	public static function create_in_dk(
+		string $sales_person_number = self::DEFAULT_SALES_PERSON_NUMBER,
+		string $employee_number = Employee::DEFAULT_EMPLOYEE_NUMBER
+	): bool|WP_Error {
+		$api_request  = new DKApiRequest();
+		$request_body = self::to_dk_sales_person_body(
+			$sales_person_number,
+			$employee_number
+		);
+
+		$result = $api_request->request_result(
+			self::API_PATH,
+			wp_json_encode( $request_body )
+		);
+
+		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		if ( 200 !== $result->response_code ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get a sales person from DK
+	 *
+	 * @param string $sales_person_number The sales person number.
+	 */
+	public static function get_from_dk(
+		string $sales_person_number = self::DEFAULT_SALES_PERSON_NUMBER
+	): stdClass|bool|WP_Error {
+		$api_request = new DKApiRequest();
+
+		$result = $api_request->get_result(
+			self::API_PATH . $sales_person_number
+		);
+
+		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		if ( 200 !== $result->response_code ) {
+			return false;
+		}
+
+		return $result->data;
+	}
+
+	/**
+	 * Check if a sales person is in DK
+	 *
+	 * @param string $sales_person_number The sales person number.
+	 */
+	public static function is_in_dk(
+		string $sales_person_number = self::DEFAULT_SALES_PERSON_NUMBER
+	): bool|WP_Error {
+		$dk_record = self::get_from_dk( $sales_person_number );
+
+		if ( $dk_record instanceof stdClass ) {
+			return true;
+		}
+
+		return $dk_record;
+	}
+
+	/**
+	 * Prepare a POST request body
+	 *
+	 * @param string $sales_person_number The sales person number.
+	 * @param string $employee_number The employee number.
+	 */
+	public static function to_dk_sales_person_body(
+		string $sales_person_number = self::DEFAULT_SALES_PERSON_NUMBER,
+		string $employee_number = Employee::DEFAULT_EMPLOYEE_NUMBER
+	): array {
+		return array(
+			'Number'            => $sales_person_number,
+			'Employee'          => $employee_number,
+			'NameOnSalesOrders' => __( 'Online Store', 'NineteenEightyWoo' ),
+			'PriceGroup'        => 0,
+			'Price1Closed'      => false,
+			'Price2Closed'      => false,
+			'Price3Closed'      => false,
+			'CanChangeDueDate'  => true,
+			'FilterOnCustomer'  => false,
+		);
+	}
+}

--- a/src/Rest/Settings.php
+++ b/src/Rest/Settings.php
@@ -28,6 +28,7 @@ class Settings {
 			"default_kennitala": { "type": "string" },
 			"kennitala_classic_field_enabled": { "type": "boolean" },
 			"kennitala_block_field_enabled": { "type": "boolean" },
+			"default_sales_person": { "type": "string" },
 			"payment_methods": {
 				"type": "array",
 				"items": {
@@ -125,6 +126,12 @@ class Settings {
 		if ( true === property_exists( $rest_json, 'enable_kennitala' ) ) {
 			Config::set_kennitala_classic_field_enabled(
 				$rest_json->enable_kennitala
+			);
+		}
+
+		if ( true === property_exists( $rest_json, 'default_sales_person' ) ) {
+			Config::set_default_sales_person_number(
+				$rest_json->default_sales_person
 			);
 		}
 

--- a/views/admin.php
+++ b/views/admin.php
@@ -2,6 +2,7 @@
 
 declare(strict_types = 1);
 
+use NineteenEightyFour\NineteenEightyWoo\Admin;
 use NineteenEightyFour\NineteenEightyWoo\Config;
 use NineteenEightyFour\NineteenEightyWoo\Import\SalesPayments;
 use NineteenEightyFour\NineteenEightyWoo\Hooks\KennitalaField;
@@ -201,7 +202,7 @@ $wc_payment_gateways = new WC_Payment_Gateways();
 					<tr>
 						<th span="row" class="column-title column-primary">
 							<label for="default_kennitala_field">
-								Default Kennitala
+								Default Customer Kennitala
 							</label>
 						</th>
 						<td>
@@ -275,6 +276,43 @@ $wc_payment_gateways = new WC_Payment_Gateways();
 			</table>
 		</section>
 
+		<section class="section">
+			<h2><?php esc_html_e( 'Default Sales Person', 'NineteenEightyWoo' ); ?></h2>
+			<p>
+				<?php
+				esc_html_e(
+					'DK requires a sales person to be assigned to every order and invoice. Generally, this would be a pseudo-person called “Web Sales” or something similar but can also be assigned to a specific sales person or employee.',
+					'NineteenEightyWoo'
+				);
+				?>
+			</p>
+			<p>
+				<?php
+				esc_html_e(
+					'If no sales person or employee exsists in your DK environment with the identifier entered above, a new one will be created along with an associated employee record.',
+					'NineteenEightyWoo'
+				);
+				?>
+			<table id="dk-kennitala-table" class="form-table">
+				<tbody>
+					<tr>
+						<th span="row" class="column-title column-primary">
+							<label for="default_sales_person_field">
+								<?php esc_html_e( 'Default Sales Person Number', 'NineteenEightyWoo' ); ?>
+							</label>
+						</th>
+						<td>
+							<input
+								id="default_sales_person_field"
+								name="default_sales_person"
+								type="text"
+								value="<?php echo esc_attr( Config::get_default_sales_person_number() ); ?>"
+							/>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</section>
 
 		<div class="submit-container">
 			<div id="nineteen-eighty-woo-settings-error" class="hidden" aria-live="polite">
@@ -316,7 +354,7 @@ $wc_payment_gateways = new WC_Payment_Gateways();
 		</p>
 		<img
 			alt="<?php esc_attr_e( 'Ninteen-Eighty-Four', 'NineteenEightyWoo' ); ?>"
-			src="<?php echo esc_attr( NineteenEightyFour\NineteenEightyWoo\Admin::logo_url() ); ?>"
+			src="<?php echo esc_attr( Admin::logo_url() ); ?>"
 		/>
 	</div>
 </div>


### PR DESCRIPTION
Adding a text field to let the store owner specify a "sales person" from DK to assign to orders and invoices. If none exists, a new one will be created along with an associated employee record.