### PR TITLE
Adding a typo to enable neative inventory

### DIFF
--- a/src/Export/Product.php
+++ b/src/Export/Product.php
@@ -141,6 +141,11 @@ class Product {
 		if ( true === $new_product ) {
 			$product_props['ItemCode'] = $product->get_sku();
 
+			// I'm not kidding. DK left this typo in their API!
+			// The docs use `AllowNegativeInventory` but this is the key that
+			// actually works.
+			$product_props['AllowNegativeInventiry'] = true;
+
 			$product_props['AllowDiscount'] = true;
 
 			if ( 'reduced-rate' === $product->get_tax_class( 'edit' ) ) {


### PR DESCRIPTION
DK has a very stupid typo in its API that is not mentioned in the docs. We need to spell inventory as "inventiry" for things to work.