### PR TITLE
Making sure that the activation and deactivation hooks work

### DIFF
--- a/1984-dk-woo.php
+++ b/1984-dk-woo.php
@@ -34,10 +34,10 @@ new Hooks\WooUpdateProduct();
 
 register_activation_hook(
 	__FILE__,
-	__NAMESPACE__ . '\Cron\Schedule::activate'
+	'NineteenEightyFour\NineteenEightyWoo\Cron\Schedule::activate'
 );
 
 register_deactivation_hook(
 	__FILE__,
-	__NAMESPACE__ . '\Cron\Schedule::deactivate'
+	'NineteenEightyFour\NineteenEightyWoo\Cron\Schedule::deactivate'
 );


### PR DESCRIPTION
The activation hook wasn't firing on plugin activation but after using the full class name, including the namespace like this, it suddenly works.