### PR TITLE
Using "processing" as the "payment complete" status

### DIFF
--- a/src/Hooks/WooOrderStatusChanges.php
+++ b/src/Hooks/WooOrderStatusChanges.php
@@ -24,7 +24,7 @@ class WooOrderStatusChanges {
 	 */
 	public function __construct() {
 		add_action(
-			'woocommerce_order_status_completed',
+			'woocommerce_order_status_processing',
 			array( __CLASS__, 'send_invoice_on_payment' ),
 			10,
 			1


### PR DESCRIPTION
This is what card payment plugins set the status to on successful payment. Confirmed using the Teya plugin.

I was assuming this was suppsed to be the "completed" status, but that means "fulfilled" in Shopify terms, which is the next step after.