### PR TITLE
Adding support for payment modes for invoices

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -57,6 +57,7 @@ class NineteenEightyWoo {
 			let enableKennitalaInBlock = Boolean( formData.get( 'enable_kennitala_in_block' ) );
 			let defaultSalesPerson     = formData.get( 'default_sales_person' ).trim();
 			let paymentIds             = formData.getAll( 'payment_id' );
+			let paymentModes           = formData.getAll( 'payment_mode' );
 			let ledgerCodeStandard     = formData.get( 'ledger_code_standard' ).trim();
 			let ledgerCodeReduced      = formData.get( 'ledger_code_reduced' ).trim();
 			let ledgerCodeShipping     = formData.get( 'ledger_code_shipping' ).trim();
@@ -65,8 +66,9 @@ class NineteenEightyWoo {
 			let paymentsLength         = paymentIds.length;
 
 			for (let i = 0; i < paymentsLength; i++) {
-				let wooId = NineteenEightyWoo.rowElements()[i].dataset.gatewayId;
-				let dkId  = parseInt( paymentIds[i] );
+				let wooId  = NineteenEightyWoo.rowElements()[i].dataset.gatewayId;
+				let dkId   = parseInt( paymentIds[i] );
+				let dkMode = paymentModes[i];
 
 				if (isNaN( dkId )) {
 					dkId = 0;
@@ -74,8 +76,9 @@ class NineteenEightyWoo {
 
 				paymentMethods.push(
 					{
-						woo_id: wooId,
-						dk_id: dkId,
+						woo_id:  wooId,
+						dk_id:   dkId,
+						dk_mode: dkMode,
 					}
 				);
 			}

--- a/src/Config.php
+++ b/src/Config.php
@@ -77,6 +77,7 @@ class Config {
 	 *
 	 * @param string $woo_id The alphanumeric WooCommerce payment ID.
 	 * @param int    $dk_id The payment method ID in DK.
+	 * @param string $dk_mode The payment mode from DK.
 	 *
 	 * @return bool True if the mapping is saved in the wp_options table, false if not.
 	 */
@@ -165,7 +166,7 @@ class Config {
 	 * processing and collection service.
 	 *
 	 * @param string $woo_id The WooCommrece gateway ID.
-	 * @param int    $dk_mode The DK payment mode.
+	 * @param string $dk_mode The DK payment mode.
 	 */
 	public static function payment_mode_matches(
 		string $woo_id,

--- a/src/Config.php
+++ b/src/Config.php
@@ -83,6 +83,7 @@ class Config {
 	public static function set_payment_mapping(
 		string $woo_id,
 		int $dk_id,
+		string $dk_mode,
 	): bool {
 		$dk_payment_method = ImportSalesPayments::find_by_id( $dk_id );
 
@@ -96,6 +97,7 @@ class Config {
 				'woo_id'  => $woo_id,
 				'dk_id'   => $dk_payment_method->dk_id,
 				'dk_name' => $dk_payment_method->dk_name,
+				'dk_mode' => $dk_mode,
 			)
 		);
 	}
@@ -119,6 +121,7 @@ class Config {
 				'woo_id'  => '',
 				'dk_id'   => '',
 				'dk_name' => '',
+				'dk_mode' => '',
 			);
 		} else {
 			$default = false;
@@ -146,6 +149,34 @@ class Config {
 		);
 
 		if ( $payment_mapping->dk_id === $dk_id ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if WooCommerce Payment Gateweay ID and DK Payment Mode match
+	 *
+	 * Even if we have payment methods per payment (and DK invoices can have
+	 * multiple payments applied), an overall payment mode seems to be added.
+	 *
+	 * This seems to default on IB, which is the Icelandic bank payment
+	 * processing and collection service.
+	 *
+	 * @param string $woo_id The WooCommrece gateway ID.
+	 * @param int    $dk_mode The DK payment mode.
+	 */
+	public static function payment_mode_matches(
+		string $woo_id,
+		string $dk_mode
+	): bool {
+		$payment_mapping = self::get_payment_mapping(
+			$woo_id,
+			true
+		);
+
+		if ( $payment_mapping->dk_mode === $dk_mode ) {
 			return true;
 		}
 

--- a/src/Export/Invoice.php
+++ b/src/Export/Invoice.php
@@ -209,7 +209,7 @@ class Invoice {
 				$wc_order->get_payment_method()
 			);
 
-			$invoice_body['PaymentMode'] = strtolower(
+			$invoice_body['Mode'] = strtolower(
 				$payment_mapping->dk_mode
 			);
 

--- a/src/Export/Invoice.php
+++ b/src/Export/Invoice.php
@@ -209,6 +209,10 @@ class Invoice {
 				$wc_order->get_payment_method()
 			);
 
+			$invoice_body['PaymentMode'] = strtolower(
+				$payment_mapping->dk_mode
+			);
+
 			$invoice_body['Payments'] = array(
 				array(
 					'ID'     => $payment_mapping->dk_id,

--- a/src/Import/SalesPayments.php
+++ b/src/Import/SalesPayments.php
@@ -16,6 +16,40 @@ use WP_Error;
 class SalesPayments {
 	const TRANSIENT_EXPIRY = 600;
 
+	const DK_PAYMENT_MODES = array(
+		'ABG',
+		'BM',
+		'CG',
+		'GKR',
+		'GM',
+		'IB',
+		'STGR',
+		'TGR',
+	);
+
+	public static function get_payment_mode_name( $key ) {
+		switch ( $key ) {
+			case 'ABG':
+				return __( 'A or B Giro Request (ABG)', '1984-dk-woo' );
+			case 'BM':
+				return __( 'Bank Transfer (BM)', '1984-dk-woo' );
+			case 'CG':
+				return __( 'C Giro Request (CG)', '1984-dk-woo' );
+			case 'GKR':
+				return __( 'Card Payment (GKR)', '1984-dk-woo' );
+			case 'GM':
+				return __( 'Giro Transfer (GM)', '1984-dk-woo' );
+			case 'IB':
+				return __( 'Bank Collection Service (IB)', '1984-dk-woo' );
+			case 'STGR':
+				return __( 'Cash Payment (STGR)', '1984-dk-woo' );
+			case 'TGR':
+				return __( 'Cheque Payment (TGR)', '1984-dk-woo' );
+			default:
+				return false;
+		}
+	}
+
 	/**
 	 * Get payment methods
 	 *

--- a/src/Import/SalesPayments.php
+++ b/src/Import/SalesPayments.php
@@ -27,7 +27,14 @@ class SalesPayments {
 		'TGR',
 	);
 
-	public static function get_payment_mode_name( $key ) {
+	/**
+	 * Get the name of a payment mode from key
+	 *
+	 * @param string $key The payment mode key from DK_PAYMENT_MODES.
+	 *
+	 * @return string The full name of the payment mode.
+	 */
+	public static function get_payment_mode_name( string $key ): string {
 		switch ( $key ) {
 			case 'ABG':
 				return __( 'A or B Giro Request (ABG)', '1984-dk-woo' );

--- a/src/Rest/Settings.php
+++ b/src/Rest/Settings.php
@@ -178,7 +178,8 @@ class Settings {
 		foreach ( $rest_json->payment_methods as $p ) {
 			Config::set_payment_mapping(
 				$p->woo_id,
-				$p->dk_id
+				$p->dk_id,
+				$p->dk_mode,
 			);
 		}
 

--- a/tests/RestSettingsTest.php
+++ b/tests/RestSettingsTest.php
@@ -21,9 +21,9 @@ final class RestSettingstest extends TestCase {
 		'customer_number_prefix' => 'WCN',
 		'payment_methods'        => array(
 			array(
-				'woo_id'       => 'bacs',
-				'dk_id'        => 10,
-				'payment_mode' => 'GKR'
+				'woo_id'  => 'bacs',
+				'dk_id'   => 10,
+				'dk_mode' => 'GKR'
 			),
 		),
 	);

--- a/tests/RestSettingsTest.php
+++ b/tests/RestSettingsTest.php
@@ -16,16 +16,17 @@ use function PHPUnit\Framework\assertIsString;
 
 #[TestDox( 'The Rest Settings JSON API endpoint class' )]
 final class RestSettingstest extends TestCase {
-	const VALID_POST_BODY = [
+	const VALID_POST_BODY = array(
 		'api_key'                => '3541031f-baf2-4737-a7e8-c66396e5a5e3',
 		'customer_number_prefix' => 'WCN',
-		'payment_methods'        => [
-			[
-				'woo_id'  => 'bacs',
-				'dk_id'   => 10
-			],
-		],
-	];
+		'payment_methods'        => array(
+			array(
+				'woo_id'       => 'bacs',
+				'dk_id'        => 10,
+				'payment_mode' => 'GKR'
+			),
+		),
+	);
 
 	/**
 	 * The WordPress administrator user

--- a/views/admin.php
+++ b/views/admin.php
@@ -128,6 +128,27 @@ $wc_payment_gateways = new WC_Payment_Gateways();
 									<?php endforeach ?>
 								</select>
 							</td>
+							<td>
+								<select
+									id="payment_mode_input_<?php echo esc_attr( $p->id ); ?>"
+									name="payment_mode"
+								>
+									<?php foreach ( SalesPayments::DK_PAYMENT_MODES as $payment_mode ) : ?>
+										<option
+											value="<?php echo esc_attr( $payment_mode ); ?>"
+											<?php echo esc_attr( Config::payment_mode_matches( $p->id, $payment_mode ) ? 'selected="true"' : '' ); ?>
+										>
+											<?php
+											echo esc_attr(
+												SalesPayments::get_payment_mode_name(
+													$payment_mode
+												)
+											);
+											?>
+										</option>
+									<?php endforeach ?>
+								</select>
+							</td>
 						</tr>
 					<?php endforeach ?>
 				</tbody>


### PR DESCRIPTION
Even if we have payment methods per payment (and DK invoices can have multiple payments applied), an overall payment mode seems to be added.

This seems to default on IB, which is the Icelandic bank payment processing and collection service.