### PR TITLE
Correcting the Payments array for invoices

### DIFF
--- a/src/Export/Invoice.php
+++ b/src/Export/Invoice.php
@@ -205,9 +205,9 @@ class Invoice {
 
 			$invoice_body['Payments'] = array(
 				array(
-				'ID'     => $payment_mapping->dk_id,
-				'Name'   => $payment_mapping->dk_name,
-				'Amount' => $wc_order->get_total(),
+					'ID'     => $payment_mapping->dk_id,
+					'Name'   => $payment_mapping->dk_name,
+					'Amount' => $wc_order->get_total(),
 				),
 			);
 		}

--- a/src/Export/Invoice.php
+++ b/src/Export/Invoice.php
@@ -204,9 +204,11 @@ class Invoice {
 			);
 
 			$invoice_body['Payments'] = array(
+				array(
 				'ID'     => $payment_mapping->dk_id,
 				'Name'   => $payment_mapping->dk_name,
 				'Amount' => $wc_order->get_total(),
+				),
 			);
 		}
 


### PR DESCRIPTION
The JSON Payments attribute is supposed to be an array of objects, because DK can handle multiple payments per invoice.