### PR TITLE
Downgrading math package and PHP requirement

### DIFF
--- a/1984-dk-woo.php
+++ b/1984-dk-woo.php
@@ -6,7 +6,7 @@
  * Description: Sync your WooCommerce store with DK, including prices, inventory status and generate invoices for customers on checkout.
  * Version: 0.1.6
  * Requires at least: 6.1.5
- * Requires PHP: 8.1
+ * Requires PHP: 8.0
  * Author: 1984 Hosting
  * Author URI: https://1984.hosting
  * License: GPL-3.0-or-later

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require": {
         "opis/json-schema": "^2.0@dev",
         "typisttech/imposter-plugin": "^0.6.0@dev",
-        "brick/math": "^0.12"
+        "brick/math": "^0.11"
     },
     "extra": {
         "imposter": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,29 +4,29 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "750040e20a6bd213e9ec371bd5cc11f0",
+    "content-hash": "848848ce7323db3d2fa925db70cb15b5",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.12.1",
+            "version": "0.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
+                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
-                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
+                "url": "https://api.github.com/repos/brick/math/zipball/0ad82ce168c82ba30d1c01ec86116ab52f589478",
+                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.0"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^10.1",
-                "vimeo/psalm": "5.16.0"
+                "phpunit/phpunit": "^9.0",
+                "vimeo/psalm": "5.0.0"
             },
             "type": "library",
             "autoload": {
@@ -46,17 +46,12 @@
                 "arithmetic",
                 "bigdecimal",
                 "bignum",
-                "bignumber",
                 "brick",
-                "decimal",
-                "integer",
-                "math",
-                "mathematics",
-                "rational"
+                "math"
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.12.1"
+                "source": "https://github.com/brick/math/tree/0.11.0"
             },
             "funding": [
                 {
@@ -64,7 +59,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-29T23:19:16+00:00"
+            "time": "2023-01-15T23:15:59+00:00"
         },
         {
             "name": "opis/json-schema",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: @1984cto, @aldavigdis, @drupalviking
 Tags: DK, dkPlus, Accounting, Inventory, Invoicing
 Requires at least: 6.2.4
 Tested up to: 6.5
-Requires PHP: 8.1
+Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
- Using `brick/math` 0.12
- Downgrading PHP requirement to 8.0