### PR TITLE
Adding rudamentary currency conversion support

### DIFF
--- a/src/Cron/Hourly.php
+++ b/src/Cron/Hourly.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace NineteenEightyFour\NineteenEightyWoo\Cron;
 
+use NineteenEightyFour\NineteenEightyWoo\Import\SalesPayments as ImportSalesPayments;
+use NineteenEightyFour\NineteenEightyWoo\Import\Currencies as ImportCurrencies;
 use NineteenEightyFour\NineteenEightyWoo\Import\Products as ImportProducts;
 
 /**
@@ -18,6 +20,8 @@ class Hourly {
 	 * Saves all products from the DK API.
 	 */
 	public static function run(): void {
+		ImportSalesPayments::get_methods();
+		ImportCurrencies::save_all_from_dk();
 		ImportProducts::save_all_from_dk();
 	}
 }

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace NineteenEightyFour\NineteenEightyWoo;
+
+use NineteenEightyFour\NineteenEightyWoo\Brick\Math\BigDecimal;
+use NineteenEightyFour\NineteenEightyWoo\Brick\Math\RoundingMode;
+use WP_Error;
+
+/**
+ * The Currency Class
+ *
+ * Handles currenty conversion and rates. This one is important when the
+ * WooCommerce uses a different currency from DK.
+ */
+class Currency {
+	const BASE_CURRENCY       = 'ISK';
+	const CURRENCY_CODE_REGEX = '/^[A-Z|a-z]{3}$/';
+
+	/**
+	 * Set a currency rate
+	 *
+	 * This sets a currency rate against the base currency (ISK)
+	 *
+	 * @param string    $currency The 3 digit ISO currency code such as EUR or USD.
+	 * @param int|float $rate The currency rate against the base currency.
+	 *
+	 * @return bool|WP_Error True or false depending on if the value was
+	 *                       successfully written into the database or not,
+	 *                       WP_Error on error.
+	 */
+	public static function set_rate(
+		string $currency,
+		int|float $rate
+	): bool|WP_Error {
+		if ( 1 !== preg_match( self::CURRENCY_CODE_REGEX, $currency ) ) {
+			return self::invalid_currency_code_error( $currency );
+		}
+
+		$option_name = '1984_woo_dk_currency_rate_' . strtolower( $currency );
+
+		$float_value = (float) $rate;
+
+		return update_option( $option_name, $float_value );
+	}
+
+	/**
+	 * Get a currency rate
+	 *
+	 * Gets a currency rate. The rate is against the base currency.
+	 *
+	 * @param string $currency The 3 digit ISO currency code such as EUR or USD.
+	 *
+	 * @return float|WP_Error A floating point representation of the currency
+	 *                        rate on success. WP_Error on error.
+	 */
+	public static function get_rate(
+		string $currency
+	): float|WP_Error {
+		if ( 1 !== preg_match( self::CURRENCY_CODE_REGEX, $currency ) ) {
+			return self::invalid_currency_code_error( $currency );
+		}
+
+		$option_name = '1984_woo_dk_currency_rate_' . strtolower( $currency );
+
+		$rate = get_option( $option_name, 0 );
+
+		if ( false === $rate ) {
+			return self::rate_not_set_error( $currency );
+		}
+
+		return (float) get_option( $option_name, 0 );
+	}
+
+	/**
+	 * Convert an amount between two different currencies
+	 *
+	 * @param int|float $amount The currency amount.
+	 * @param string    $from The 3 digit ISO code for the currency to convert from.
+	 * @param string    $to The 3 digit ISO code for the currency to convert to.
+	 *
+	 * @return float|WP_Error A floating point representation of the converted
+	 *                        amount, or WP_Error in case of error.
+	 */
+	public static function convert(
+		int|float $amount,
+		string $from,
+		string $to = self::BASE_CURRENCY
+	): float|WP_Error {
+		if ( 1 !== preg_match( self::CURRENCY_CODE_REGEX, $from ) ) {
+			return self::invalid_currency_code_error( $from );
+		}
+
+		if ( 1 !== preg_match( self::CURRENCY_CODE_REGEX, $to ) ) {
+			return self::invalid_currency_code_error( $to );
+		}
+
+		$from_rate = get_option(
+			'1984_woo_dk_currency_rate_' . strtolower( $from ),
+		);
+
+		if ( false === $from_rate ) {
+			return self::rate_not_set_error( $from );
+		}
+
+		$amount_decimal    = BigDecimal::of( $amount );
+		$from_rate_decimal = BigDecimal::of( $from_rate );
+
+		$base_currency_amount = $amount_decimal->multipliedBy(
+			$from_rate_decimal
+		);
+
+		if ( self::BASE_CURRENCY === $to ) {
+			return $base_currency_amount->toFloat();
+		}
+
+		$to_rate = get_option(
+			'1984_woo_dk_currency_rate_' . strtolower( $to )
+		);
+
+		if ( false === $to_rate ) {
+			return self::rate_not_set_error( $to );
+		}
+
+		return $base_currency_amount->multipliedBy(
+			BigDecimal::of( 1 )->dividedBy(
+				$to_rate,
+				12,
+				RoundingMode::HALF_UP
+			)
+		)->toFloat();
+	}
+
+	/**
+	 * Generate a WP_Error about an invalid currency code
+	 *
+	 * @param string $currency_code The currency code as it was entered.
+	 */
+	public static function invalid_currency_code_error(
+		string $currency_code
+	): WP_Error {
+		return new WP_Error(
+			'currency-code-invalid',
+			sprintf(
+				// Translators: The %s stands for the currency code.
+				__(
+					'The currency code ‘%s’ is invalid.',
+					'1984-dk-woo'
+				),
+				strtoupper( $currency_code )
+			)
+		);
+	}
+
+	/**
+	 * Generate a WP_Error about a currency rate not having been set
+	 *
+	 * @param string $currency_code The currency code as it was entered.
+	 */
+	public static function rate_not_set_error(
+		string $currency_code
+	): WP_Error {
+		return new WP_Error(
+			'currency-rate-not-set',
+			sprintf(
+				// Translators: The %s stands for the currency code.
+				__(
+					'The currency rate for ‘%s’ has not been set.',
+					'1984-dk-woo'
+				),
+				strtoupper( $currency_code )
+			)
+		);
+	}
+}

--- a/src/Import/Currencies.php
+++ b/src/Import/Currencies.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace NineteenEightyFour\NineteenEightyWoo\Import;
+
+use NineteenEightyFour\NineteenEightyWoo\Service\DKApiRequest;
+use NineteenEightyFour\NineteenEightyWoo\Currency;
+use WP_Error;
+
+/**
+ * The Currenty Import class
+ *
+ * Handles fetching currency rates
+ */
+class Currencies {
+	const API_PATH = '/General/Currency/';
+
+	/**
+	 * Save all currency rates from DK
+	 *
+	 * Fetches all the currency rates from DK
+	 */
+	public static function save_all_from_dk(): void {
+		if ( defined( 'DOING_DK_SYNC' ) ) {
+			return;
+		}
+
+		define( 'DOING_DK_SYNC', true );
+
+		$json_objects = self::get_all_from_dk();
+
+		foreach ( $json_objects as $c ) {
+			Currency::set_rate( $c->Number, $c->Rate );
+		}
+	}
+
+	/**
+	 * Get all currency rates from the DK API
+	 */
+	public static function get_all_from_dk(): false|WP_Error|array {
+		$api_request = new DKApiRequest();
+		$result      = $api_request->get_result( self::API_PATH );
+
+		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		if ( 200 !== $result->response_code ) {
+			return false;
+		}
+
+		return (array) $result->data;
+	}
+}

--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -7,6 +7,7 @@ namespace NineteenEightyFour\NineteenEightyWoo\Import;
 use NineteenEightyFour\NineteenEightyWoo\Service\DKApiRequest;
 use NineteenEightyFour\NineteenEightyWoo\Brick\Math\BigDecimal;
 use NineteenEightyFour\NineteenEightyWoo\Brick\Math\RoundingMode;
+use NineteenEightyFour\NineteenEightyWoo\Currency;
 use DateTime;
 use stdClass;
 use WC_DateTime;
@@ -31,7 +32,7 @@ class Products {
 		'UnitPrice1,UnitPrice1WithTax,Inactive,NetWeight,UnitVolume,' .
 		'TotalQuantityInWarehouse,UnitPrice1,TaxPercent,' .
 		'AllowNegativeInventiry,ExtraDesc1,ExtraDesc2,ShowItemInWebShop,' .
-		'Inactive,Deleted,PropositionDateTo,PropositionDateFrom';
+		'Inactive,Deleted,PropositionDateTo,PropositionDateFrom,CurrencyCode';
 
 	/**
 	 * Save all products from DK
@@ -259,19 +260,46 @@ class Products {
 			0 === $product_id ||
 			true === (bool) $wc_product->get_meta( '1984_woo_dk_price_sync' )
 		) {
+			$store_currency = get_woocommerce_currency();
+			$dk_currency    = $json_object->CurrencyCode;
+
+			if ( $store_currency === $dk_currency ) {
+				// Don't convert anything if the product's currency and the
+				// store currency are the same.
+				$price          = $json_object->UnitPrice1;
+				$price_with_tax = $json_object->UnitPrice1WithTax;
+				$sale_price     = $json_object->PropositionPrice;
+			} else {
+				// If the product's currency and store currency don't match,
+				// convert the prices to the store's currency.
+				$price = Currency::convert(
+					$json_object->UnitPrice1,
+					$dk_currency,
+					$store_currency
+				);
+
+				$price_with_tax = Currency::convert(
+					$json_object->UnitPrice1WithTax,
+					$dk_currency,
+					$store_currency
+				);
+
+				$sale_price = Currency::convert(
+					$json_object->PropositionPrice,
+					$dk_currency,
+					$store_currency
+				);
+			}
+
 			if ( true === wc_prices_include_tax() ) {
 				$wc_product->set_tax_class(
 					self::tax_class_from_rate( $json_object->TaxPercent )
 				);
 
-				$wc_product->set_regular_price(
-					$json_object->UnitPrice1WithTax
-				);
+				$wc_product->set_regular_price( $price_with_tax );
 
 				if ( 0 < $json_object->PropositionPrice ) {
-					$sale_price_before_tax = BigDecimal::of(
-						$json_object->PropositionPrice,
-					);
+					$sale_price_before_tax = BigDecimal::of( $sale_price );
 
 					$sale_tax_percentage = BigDecimal::of(
 						$json_object->TaxPercent
@@ -294,44 +322,32 @@ class Products {
 					$wc_product->set_sale_price( '' );
 				}
 			} else {
-				$wc_product->set_regular_price( $json_object->UnitPrice1 );
+				$wc_product->set_regular_price( $price );
 
 				if ( 0 > $json_object->PropositionPrice ) {
-					$wc_product->set_sale_price(
-						$json_object->PropositionPrice
-					);
+					$wc_product->set_sale_price( $sale_price );
 				} else {
 					$wc_product->set_sale_price( '' );
 				}
 			}
 
-			if (
-				true === property_exists(
-					$json_object,
-					'PropositionDateFrom'
-				)
-			) {
+			if ( property_exists( $json_object, 'PropositionDateFrom' ) ) {
 				$wc_product->set_date_on_sale_from(
 					new WC_DateTime( $json_object->PropositionDateFrom )
 				);
 			}
-			if (
-				true === property_exists(
-					$json_object,
-					'PropositionDateTo'
-				)
-			) {
+			if ( property_exists( $json_object, 'PropositionDateTo' ) ) {
 				$wc_product->set_date_on_sale_to(
 					new WC_DateTime( $json_object->PropositionDateTo )
 				);
 			}
 		}
 
-		$date_and_time = new DateTime();
+		$current_date_and_time = new DateTime();
 
 		$wc_product->update_meta_data(
 			'last_downstream_sync',
-			$date_and_time->format( 'U' )
+			$current_date_and_time->format( 'U' )
 		);
 
 		return $wc_product;

--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -278,6 +278,14 @@ class Products {
 					$store_currency
 				);
 
+				// If there is an error in the currency conversion (for example
+				// if the rate has not been set yet), we return false here,
+				// indicating that we are skipping the import of this specific
+				// product.
+				if ( $price instanceof WP_Error ) {
+					return false;
+				}
+
 				$price_with_tax = Currency::convert(
 					$json_object->UnitPrice1WithTax,
 					$dk_currency,

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -2,7 +2,12 @@
 
 declare(strict_types = 1);
 
+use NineteenEightyFour\NineteenEightyWoo\Currency;
+
 require __DIR__ . '/../vendor/aldavigdis/wp-tests-strapon/bootstrap.php';
 require __DIR__ . '/../vendor/woocommerce/woocommerce/woocommerce.php';
 
 WC_Install::install();
+
+Currency::set_rate( 'EUR', 155.55 );
+update_option( 'woocommerce_currency', 'ISK' );


### PR DESCRIPTION
This enables us to support DK installations that use a different currenty from the customer facing currency for their accounting.

In particular, businesses using EUR for their acocunting can have their prices show up in ISK.

There's a bit left to do here though; especially disabling price sync by default and adding a "FOREX surcharge" to the store prices.

This is the basis for solving ticket #116.