### PR TITLE
Bugfix: Non-web products imported on update

### DIFF
--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -373,6 +373,10 @@ class Products {
 			(
 				property_exists( $json_object, 'Deleted' ) &&
 				$json_object->Deleted
+			) ||
+			(
+				! Config::get_import_nonweb_products() &&
+				$json_object->ShowItemInWebShop === false
 			)
 		) {
 			wp_delete_post( $wc_product->get_id() );


### PR DESCRIPTION
The Products::update_product_from_json function did was importing non-web products, even if the settings said otherwise. Now non-web products are deleted from WooCommerce instead of being labelled as drafts.